### PR TITLE
Directly link to lever for now

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
   <h1 class="scale-huge line-height-0 mt0 mb1"><a class="semidecorate" href="https://plangrid.com">PlanGrid</a></h1>
   <p class="scale-subhuge line-height-0 mt0">Build with confidence.
   <ul class="line-height-4 list-reset">
-    <li><a href="https://www.plangrid.com/jobs/">Jobs</a>
+    <li><a href="https://jobs.lever.co/plangrid/">Jobs</a>
     <li><a href="https://github.com/plangrid">Github</a>
   </ul>
 </div>


### PR DESCRIPTION
Link direct to https://jobs.lever.co/plangrid/ for now on https://plangrid.github.io because all these links are currently are <q><b>Page Not found</b></q>

- https://www.plangrid.com/jobs
- https://www.plangrid.com/jobs/
- https://www.plangrid.com/careers
- https://www.plangrid.com/careers/

Ideally all these would redirect